### PR TITLE
Add EXP stats and prepare build for clang++/MinGW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,29 @@
-
 CXX ?= clang++
-SRC_DIR := src
 BUILD_DIR := build
-SOURCES := $(wildcard $(SRC_DIR)/*.cpp)
-OBJECTS := $(patsubst $(SRC_DIR)/%.cpp,$(BUILD_DIR)/%.o,$(SOURCES))
+SOURCES := $(wildcard *.cpp)
+OBJECTS := $(patsubst %.cpp,$(BUILD_DIR)/%.o,$(SOURCES))
 TARGET := $(BUILD_DIR)/ExperienceViewer.exe
 
 CXXFLAGS += -std=c++20 -O2 -municode -DUNICODE -D_UNICODE -Wall -Wextra
 LDFLAGS  += -mwindows
 LIBS := -lcomdlg32 -lcomctl32 -luser32 -lgdi32 -lshell32 -ladvapi32 -lole32 -lgdiplus -lshlwapi
+.RECIPEPREFIX := >
 
 all: $(TARGET)
+
 $(BUILD_DIR):
-	mkdir -p $(BUILD_DIR)
-$(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp | $(BUILD_DIR)
-	$(CXX) $(CXXFLAGS) -c $< -o $@
+>mkdir -p $(BUILD_DIR)
+
+$(BUILD_DIR)/%.o: %.cpp | $(BUILD_DIR)
+>$(CXX) $(CXXFLAGS) -c $< -o $@
+
 $(TARGET): $(OBJECTS)
-	$(CXX) $(OBJECTS) $(LDFLAGS) -o $@ $(LIBS)
-	@echo Copy assets...
-	@mkdir -p $(BUILD_DIR)/assets
-	@cp -f assets/*.png $(BUILD_DIR)/assets/ || true
-	@echo copy assets done # copy assets
+>$(CXX) $(OBJECTS) $(LDFLAGS) -o $@ $(LIBS)
+>@echo Copy assets...
+>@mkdir -p $(BUILD_DIR)/assets
+>@cp -f assets/*.png $(BUILD_DIR)/assets/ || true
+>@echo copy assets done # copy assets
+
 clean:
-	rm -rf $(BUILD_DIR)
+>rm -rf $(BUILD_DIR)
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@
 
 ## Build
 ```bash
+# con clang++
 make -j8 CXX=clang++
+# o con g++ de MinGW-w64
+make -j8 CXX=x86_64-w64-mingw32-g++
 # binario: build/ExperienceViewer.exe
 ```
-Requiere MinGW-w64/Clang y GDI+ (ya enlazado con `-lgdiplus`).
+Requiere MinGW-w64 y GDI+ (ya enlazado con `-lgdiplus`).

--- a/gui.cpp
+++ b/gui.cpp
@@ -247,7 +247,10 @@ static void on_open_exp(){
     if (path.empty()) return;
     if (!g_app.exp_db.load(path)) { show_message(L"Failed to load EXP file.", L"Error", MB_OK|MB_ICONERROR); return; }
     g_app.current_exp_path = path;
-    set_status(L"EXP loaded.");
+    auto st = g_app.exp_db.compute_stats();
+    std::wstringstream ws; ws.setf(std::ios::fixed); ws.precision(2);
+    ws << L"EXP loaded: " << st.entries << L" entries, avg score " << st.avg_score;
+    set_status(ws.str());
 }
 
 static void on_load_engine(){


### PR DESCRIPTION
## Summary
- show summary stats after loading an EXP file
- modernize Makefile to build all sources and work with clang++ or MinGW
- document multiple compiler options in README

## Testing
- `make -j8 CXX=clang++` *(fails: clang++: No such file or directory)*
- `make -j8 CXX=x86_64-w64-mingw32-g++` *(fails: x86_64-w64-mingw32-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acd9ef5700832792b496f798704e97