### PR TITLE
Wrap Windows GUI initialization in run_gui function

### DIFF
--- a/gui.cpp
+++ b/gui.cpp
@@ -516,6 +516,7 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPara
     return 0;
 }
 
+int run_gui(HINSTANCE hInstance) {
     WNDCLASSEXW wc{};
     wc.cbSize = sizeof(wc);
     wc.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);


### PR DESCRIPTION
## Summary
- Add run_gui function in gui.cpp to encapsulate window class registration, window creation, and message loop.

## Testing
- `mingw32-make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19f482c188327b0b6fe2483f8cd98