### PR TITLE
Improve asset lookup and UCI option dialog

### DIFF
--- a/uci_options.cpp
+++ b/uci_options.cpp
@@ -3,6 +3,7 @@
 #include "utils.h"
 #include <sstream>
 #ifdef _WIN32
+#include <commctrl.h>
 
 std::vector<UciOption> uci_parse_options(const std::string& log){
     std::vector<UciOption> v;
@@ -38,12 +39,14 @@ int show_uci_options_dialog(HWND parent,
                             const std::vector<UciOption>& opts,
                             const std::function<void(const std::string& line)>& send,
                             int& out_depth, int& out_movetime_ms){
-    const int W=420, H=180;
+    int row=24, x=12, lbl=200;
+    int rows = 2 + (int)opts.size();
+    int W=420; int H=80 + row*rows;
     HWND dlg = CreateWindowExW(WS_EX_DLGMODALFRAME, L"STATIC", L"UCI Options",
                                WS_POPUP|WS_CAPTION|WS_SYSMENU, CW_USEDEFAULT, CW_USEDEFAULT, W, H,
                                parent, nullptr, GetModuleHandleW(nullptr), nullptr);
     if (!dlg) return 0;
-    int x=12, y=12, lbl=200, row=24;
+    int y=12;
 
     CreateWindowW(L"STATIC", L"Analysis depth (0=ignore):", WS_CHILD|WS_VISIBLE, x, y+4, lbl, row, dlg, nullptr, GetModuleHandleW(nullptr), nullptr);
     wchar_t bufD[32]; _snwprintf(bufD, 32, L"%d", out_depth);
@@ -54,16 +57,54 @@ int show_uci_options_dialog(HWND parent,
     HWND edM = CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", bufM, WS_CHILD|WS_VISIBLE|ES_NUMBER, x+lbl+6, y, 100, row, dlg, nullptr, GetModuleHandleW(nullptr), nullptr);
     y += row + 12;
 
-    HWND ok = CreateWindowW(L"BUTTON", L"OK", WS_CHILD|WS_VISIBLE|BS_DEFPUSHBUTTON, W-200, H-50, 80, 28, dlg, (HMENU)1, GetModuleHandleW(nullptr), nullptr);
-    HWND ca = CreateWindowW(L"BUTTON", L"Cancel", WS_CHILD|WS_VISIBLE, W-110, H-50, 80, 28, dlg, (HMENU)2, GetModuleHandleW(nullptr), nullptr);
+    struct Ctrl { const UciOption* opt; HWND hwnd; };
+    std::vector<Ctrl> ctrls;
+    for (const auto& o : opts){
+        if (o.type=="check"){
+            HWND cb = CreateWindowW(L"BUTTON", utf8_to_wide(o.name).c_str(),
+                                    WS_CHILD|WS_VISIBLE|BS_AUTOCHECKBOX,
+                                    x, y, W-24, row, dlg, nullptr, GetModuleHandleW(nullptr), nullptr);
+            if (o.def=="true" || o.def=="1") SendMessageW(cb, BM_SETCHECK, BST_CHECKED, 0);
+            ctrls.push_back({&o, cb});
+            y += row + 4;
+        } else if (o.type=="spin" || o.type=="string"){
+            CreateWindowW(L"STATIC", utf8_to_wide(o.name).c_str(), WS_CHILD|WS_VISIBLE,
+                          x, y+4, lbl, row, dlg, nullptr, GetModuleHandleW(nullptr), nullptr);
+            std::wstring def = utf8_to_wide(o.def);
+            DWORD style = WS_CHILD|WS_VISIBLE;
+            if (o.type=="spin") style |= ES_NUMBER;
+            HWND ed = CreateWindowExW(WS_EX_CLIENTEDGE, L"EDIT", def.c_str(), style,
+                                     x+lbl+6, y, 120, row, dlg, nullptr, GetModuleHandleW(nullptr), nullptr);
+            ctrls.push_back({&o, ed});
+            y += row + 4;
+        } else if (o.type=="combo"){
+            CreateWindowW(L"STATIC", utf8_to_wide(o.name).c_str(), WS_CHILD|WS_VISIBLE,
+                          x, y+4, lbl, row, dlg, nullptr, GetModuleHandleW(nullptr), nullptr);
+            HWND cb = CreateWindowW(WC_COMBOBOXW, L"", WS_CHILD|WS_VISIBLE|CBS_DROPDOWNLIST,
+                                    x+lbl+6, y, 150, row*5, dlg, nullptr, GetModuleHandleW(nullptr), nullptr);
+            int defIdx = 0; int idx = 0;
+            for (const auto& v : o.vars){
+                std::wstring wv = utf8_to_wide(v);
+                SendMessageW(cb, CB_ADDSTRING, 0, (LPARAM)wv.c_str());
+                if (v==o.def) defIdx = idx;
+                idx++;
+            }
+            SendMessageW(cb, CB_SETCURSEL, defIdx, 0);
+            ctrls.push_back({&o, cb});
+            y += row + 4;
+        }
+    }
+
+    HWND ok = CreateWindowW(L"BUTTON", L"OK", WS_CHILD|WS_VISIBLE|BS_DEFPUSHBUTTON,
+                            W-200, H-50, 80, 28, dlg, (HMENU)1, GetModuleHandleW(nullptr), nullptr);
+    HWND ca = CreateWindowW(L"BUTTON", L"Cancel", WS_CHILD|WS_VISIBLE,
+                            W-110, H-50, 80, 28, dlg, (HMENU)2, GetModuleHandleW(nullptr), nullptr);
 
     ShowWindow(dlg, SW_SHOW);
     UpdateWindow(dlg);
-    int ret = 0;
-    bool loop=true;
+    int ret = 0; bool loop=true;
     while (loop){
-        MSG msg;
-        if (!GetMessageW(&msg, nullptr, 0, 0)) break;
+        MSG msg; if (!GetMessageW(&msg, nullptr, 0, 0)) break;
         if (msg.message==WM_KEYDOWN && msg.wParam==VK_ESCAPE){ ret=0; loop=false; }
         if (msg.message==WM_COMMAND){
             if ((HWND)msg.lParam == ok){ ret=1; loop=false; }
@@ -76,23 +117,20 @@ int show_uci_options_dialog(HWND parent,
     }
     if (ret){
         wchar_t b1[64], b2[64];
-        GetWindowTextW(edD, b1, 64);
-        GetWindowTextW(edM, b2, 64);
-        out_depth = _wtoi(b1);
-        out_movetime_ms = _wtoi(b2);
-        for (auto& o: opts){
+        GetWindowTextW(edD, b1, 64); GetWindowTextW(edM, b2, 64);
+        out_depth = _wtoi(b1); out_movetime_ms = _wtoi(b2);
+        for (auto& c : ctrls){
+            const UciOption& o = *c.opt;
             if (o.type=="check"){
-                std::string v = o.def.empty()? "false" : o.def;
-                send("setoption name " + o.name + " value " + v);
-            } else if (o.type=="spin"){
-                std::string v = o.def.empty()? "0" : o.def;
-                send("setoption name " + o.name + " value " + v);
-            } else if (o.type=="string"){
-                std::string v = o.def;
-                send("setoption name " + o.name + " value " + v);
+                bool on = SendMessageW(c.hwnd, BM_GETCHECK,0,0)==BST_CHECKED;
+                send("setoption name " + o.name + " value " + (on?"true":"false"));
+            } else if (o.type=="spin" || o.type=="string"){
+                wchar_t buf[256]; GetWindowTextW(c.hwnd, buf, 256);
+                send("setoption name " + o.name + " value " + wide_to_utf8(buf));
             } else if (o.type=="combo"){
-                std::string v = o.def.empty()? (o.vars.empty()? "" : o.vars.front()) : o.def;
-                send("setoption name " + o.name + " value " + v);
+                int sel = (int)SendMessageW(c.hwnd, CB_GETCURSEL,0,0);
+                std::string val = (sel>=0 && sel<(int)o.vars.size())? o.vars[sel] : "";
+                send("setoption name " + o.name + " value " + val);
             }
         }
     }


### PR DESCRIPTION
## Summary
- show experience moves using simple algebraic squares instead of raw UCI
- search for piece sprites in parent directory when missing, ensuring pieces render
- build dynamic UCI option dialog that creates controls for engine options

## Testing
- `make`
- `make check`
- `make distcheck`


------
https://chatgpt.com/codex/tasks/task_e_68b1ac2454188327a5f41427eac30e65