### PR TITLE
Handle object build directories automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ $(BUILD_DIR):
 >mkdir -p $(BUILD_DIR)
 
 $(BUILD_DIR)/%.o: %.cpp | $(BUILD_DIR)
->@mkdir -p $(@D)
+>mkdir -p $(dir $@)
 >$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(TARGET): $(OBJECTS)

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ $(BUILD_DIR):
 >mkdir -p $(BUILD_DIR)
 
 $(BUILD_DIR)/%.o: %.cpp | $(BUILD_DIR)
+>@mkdir -p $(@D)
 >$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(TARGET): $(OBJECTS)


### PR DESCRIPTION
## Summary
- ensure Makefile creates target directories for object files using $(@D)

## Testing
- `make`
- `make USE_QT=1` *(fails: Package Qt5Widgets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c267fcc083279f878e2606c226cb