### PR TITLE
feat: configurable assets path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - **Layout horizontal**: PGN a la izquierda; derecha = tablero + tabla de jugadas.
 - **UCI Options (Arena/Scid-like)**: diálogo dinámico a partir de `option name ...` del motor.
 - **.exp**: lectura tipo texto (CSV-like) y cruce básico por clave UCI.
-- **Detección de sprites**: la aplicación avisa si faltan imágenes de piezas en `assets/`.
+- **Detección de sprites**: la aplicación avisa si faltan imágenes de piezas en `assets/` (listando los archivos faltantes) y permite especificar la ruta mediante la variable de entorno `EV_ASSETS_DIR`.
 
 ## Build
 La aplicación puede compilarse tanto en Linux (modo consola) como en Windows

--- a/gui.h
+++ b/gui.h
@@ -2,8 +2,8 @@
 #pragma once
 #ifdef _WIN32
 #include <windows.h>
-int run_gui(HINSTANCE hInstance);
+int run_gui(HINSTANCE hInstance, const wchar_t* assets_dir = nullptr);
 #else
 typedef void* HINSTANCE;
-inline int run_gui(HINSTANCE) { return 0; }
+inline int run_gui(HINSTANCE, const wchar_t* = nullptr) { return 0; }
 #endif


### PR DESCRIPTION
## Summary
- allow GUI to load assets from an override path or `EV_ASSETS_DIR`
- report missing sprite files explicitly when assets are incomplete
- document how to set asset path via `EV_ASSETS_DIR`

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68b1cb39f4e883279f93ab69bf56607b